### PR TITLE
Configure Dependabot for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "dotnet-sdk" # See documentation for possible values
+    directories: 
+      - "/Paybills.API" # Location of package manifests
+      - "/Paybills.IntegrationTests"
+      - "/Paybills.UnitTests"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Updated package ecosystem to 'dotnet-sdk' and specified directories for Dependabot.