### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/Paybills.API/Infrastructure/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/Paybills.API/Infrastructure/Middleware/RequestResponseLoggingMiddleware.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -24,12 +25,30 @@ namespace Paybills.API.Middleware
             }
             finally
             {
+                var requestMethod = SanitizeForLog(context.Request?.Method);
+                var requestPath = SanitizeForLog(context.Request?.Path.Value);
+
                 _logger.LogInformation(
                     "Request {method} {url} => {statusCode}",
-                    context.Request?.Method,
-                    context.Request?.Path.Value,
+                    requestMethod,
+                    requestPath,
                     context.Response?.StatusCode);
             }
+        }
+
+        private static string SanitizeForLog(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return value
+                .Replace("\r\n", " ", StringComparison.Ordinal)
+                .Replace("\n", " ", StringComparison.Ordinal)
+                .Replace("\r", " ", StringComparison.Ordinal)
+                .Replace("\u2028", " ", StringComparison.Ordinal)
+                .Replace("\u2029", " ", StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Island-Software/billminder/security/code-scanning/2](https://github.com/Island-Software/billminder/security/code-scanning/2)

To fix this without changing behavior, sanitize request-derived strings before logging by removing CR/LF (and other line-separator characters) so user input cannot create forged log lines.

Best approach in this file:
- Add `using System;` (for `StringComparison`).
- Introduce a small private helper method in `RequestResponseLoggingMiddleware` to sanitize log values:
  - Return `null` unchanged.
  - Replace `\r\n`, `\n`, `\r`, and Unicode line separators (`\u2028`, `\u2029`) with safe spaces (or empty string).
- In `InvokeAsync`, sanitize `context.Request?.Method` and `context.Request?.Path.Value` before passing them to `_logger.LogInformation`.

This keeps existing logging structure and semantics intact while preventing log injection/forging via line breaks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
