### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -3,6 +3,9 @@ name: Backend API build & deploy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Island-Software/billminder/security/code-scanning/1](https://github.com/Island-Software/billminder/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/build_and_deploy.yaml` at the workflow root (top-level), right after the `on` section and before `jobs`.  
For this workflow, the minimal required permission is `contents: read` (needed by `actions/checkout`). No additional scopes are required based on the shown steps.

This is the best fix because:
- It addresses the CodeQL finding directly.
- It applies consistently to all jobs in this workflow (currently one job).
- It does not change deployment logic or runtime behavior, only token scope hardening.

No imports, methods, or external definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
